### PR TITLE
MDL-61697 tool_dataprivacy: Fix page return logic

### DIFF
--- a/datarequests.php
+++ b/datarequests.php
@@ -47,7 +47,7 @@ echo $OUTPUT->header();
 echo $OUTPUT->heading($title);
 
 $requests = tool_dataprivacy\api::get_data_requests();
-$requestlist = new tool_dataprivacy\output\data_requests_page($requests, false);
+$requestlist = new tool_dataprivacy\output\data_requests_page($requests);
 $requestlistoutput = $PAGE->get_renderer('tool_dataprivacy');
 echo $requestlistoutput->render($requestlist);
 


### PR DESCRIPTION
* Set the 'manage' flag parameter in the page URL.
* Set the page URL as the form action to preserve the 'manage' flag
parameter and be able to correctly determine the return URL.
* Bonus:
  - Use the appropriate page context in the createdatarequest.php page.
  - Fix parameters for tool_dataprivacy\output\data_requests_page()
instantiation in datarequests.php.