### PR TITLE
MDL-61271 tool_dataprivacy: Convert defaults button to action_link

### DIFF
--- a/classes/output/categories.php
+++ b/classes/output/categories.php
@@ -67,7 +67,11 @@ class categories extends crud_element implements renderable, templatable {
         $data = new stdClass();
 
         // Navigation links.
-        $data->navigation = $this->get_navigation($output);
+        $data->navigation = [];
+        $navigationlinks = $this->get_navigation();
+        foreach ($navigationlinks as $navlink) {
+            $data->navigation[] = $navlink->export_for_template($output);
+        }
 
         $data->categories = [];
         foreach ($this->categories as $category) {

--- a/classes/output/crud_element.php
+++ b/classes/output/crud_element.php
@@ -42,16 +42,16 @@ abstract class crud_element {
     /**
      * Returns the top navigation buttons.
      *
-     * @param \renderer_base $output
-     * @return \single_button[]
+     * @return \action_link[]
      */
-    protected final function get_navigation(renderer_base $output) {
-        $back = new \single_button(
+    protected final function get_navigation() {
+        $back = new \action_link(
             new \moodle_url('/admin/tool/dataprivacy/dataregistry.php'),
             get_string('back'),
-            'get'
+            null,
+            ['class' => 'btn btn-default']
         );
-        return [$output->render($back)];
+        return [$back];
     }
 
     /**

--- a/classes/output/data_registry_page.php
+++ b/classes/output/data_registry_page.php
@@ -76,11 +76,11 @@ class data_registry_page implements renderable, templatable {
         $PAGE->requires->js_call_amd('tool_dataprivacy/data_registry', 'init', $params);
 
         $data = new stdClass();
-
-        $defaultsbutton = new \single_button(
+        $defaultsbutton = new \action_link(
             new \moodle_url('/admin/tool/dataprivacy/defaults.php'),
             get_string('setdefaults', 'tool_dataprivacy'),
-            'get'
+            null,
+            ['class' => 'btn btn-default']
         );
         $data->defaultsbutton = $defaultsbutton->export_for_template($output);
 

--- a/classes/output/purposes.php
+++ b/classes/output/purposes.php
@@ -67,7 +67,11 @@ class purposes extends crud_element implements renderable, templatable {
         $data = new stdClass();
 
         // Navigation links.
-        $data->navigation = $this->get_navigation($output);
+        $data->navigation = [];
+        $navigationlinks = $this->get_navigation();
+        foreach ($navigationlinks as $navlink) {
+            $data->navigation[] = $navlink->export_for_template($output);
+        }
 
         $data->purposes = [];
         foreach ($this->purposes as $purpose) {

--- a/templates/categories.mustache
+++ b/templates/categories.mustache
@@ -47,7 +47,7 @@
 }}
 
 {{#navigation}}
-    {{{.}}}
+    {{> core/action_link}}
 {{/navigation}}
 
 <div data-region="categories" class="m-t-3 m-b-1">

--- a/templates/data_registry.mustache
+++ b/templates/data_registry.mustache
@@ -35,7 +35,7 @@
 <div class="data-registry">
     <div class="top-nav">
         {{#defaultsbutton}}
-            {{> core/single_button}}
+            {{> core/action_link}}
         {{/defaultsbutton}}
         {{#actions}}
             {{> core/action_menu}}

--- a/templates/purposes.mustache
+++ b/templates/purposes.mustache
@@ -54,7 +54,7 @@
 }}
 
 {{#navigation}}
-    {{{.}}}
+    {{> core/action_link}}
 {{/navigation}}
 
 <div data-region="purposes" class="m-t-3 m-b-1">


### PR DESCRIPTION
The core/single_button template is only available in Boost for 3.3.
Use action_link instead for the defaults button.