### PR TITLE
MDL-61874 tool_dataprivacy: Make page_helper more generic

### DIFF
--- a/categories.php
+++ b/categories.php
@@ -27,7 +27,7 @@ require_once(__DIR__ . '/../../../config.php');
 $url = new moodle_url("/admin/tool/dataprivacy/categories.php");
 $title = get_string('editcategories', 'tool_dataprivacy');
 
-\tool_dataprivacy\page_helper::setup($url, $title);
+\tool_dataprivacy\page_helper::setup($url, $title, 'dataregistry');
 
 $output = $PAGE->get_renderer('tool_dataprivacy');
 echo $output->header();

--- a/dataregistrysetup.php
+++ b/dataregistrysetup.php
@@ -27,7 +27,7 @@ require_once(__DIR__ . '/../../../config.php');
 $url = new moodle_url("/admin/tool/dataprivacy/dataregistrysetup.php");
 $title = get_string('dataregistrysetup', 'tool_dataprivacy');
 
-\tool_dataprivacy\page_helper::setup($url, $title);
+\tool_dataprivacy\page_helper::setup($url, $title, 'dataregistry');
 
 $output = $PAGE->get_renderer('tool_dataprivacy');
 echo $output->header();

--- a/datarequests.php
+++ b/datarequests.php
@@ -27,22 +27,10 @@ require_once('lib.php');
 
 $url = new moodle_url('/admin/tool/dataprivacy/datarequests.php');
 
-$PAGE->set_url($url);
-
-require_login();
-if (isguestuser()) {
-    print_error('noguest');
-}
-
-$context = context_system::instance();
-
-require_capability('tool/dataprivacy:managedatarequests', $context);
-
-$PAGE->set_context($context);
-
 $title = get_string('datarequests', 'tool_dataprivacy');
-$PAGE->set_heading($title);
-$PAGE->set_title($title);
+
+\tool_dataprivacy\page_helper::setup($url, $title, '', 'tool/dataprivacy:managedatarequests');
+
 echo $OUTPUT->header();
 echo $OUTPUT->heading($title);
 

--- a/defaults.php
+++ b/defaults.php
@@ -28,7 +28,7 @@ require_once($CFG->dirroot . '/' . $CFG->admin . '/tool/dataprivacy/lib.php');
 $url = new \moodle_url('/admin/tool/dataprivacy/defaults.php');
 $title = get_string('setdefaults', 'tool_dataprivacy');
 
-\tool_dataprivacy\page_helper::setup($url, $title);
+\tool_dataprivacy\page_helper::setup($url, $title, 'dataregistry');
 
 $levels = \context_helper::get_all_levels();
 

--- a/editcategory.php
+++ b/editcategory.php
@@ -32,7 +32,7 @@ if ($id) {
 } else {
     $title = get_string('addcategory', 'tool_dataprivacy');
 }
-\tool_dataprivacy\page_helper::setup($url, $title);
+\tool_dataprivacy\page_helper::setup($url, $title, 'dataregistry');
 
 $category = new \tool_dataprivacy\category($id);
 $form = new \tool_dataprivacy\form\category($PAGE->url->out(false),

--- a/editpurpose.php
+++ b/editpurpose.php
@@ -33,7 +33,7 @@ if ($id) {
     $title = get_string('addpurpose', 'tool_dataprivacy');
 }
 
-\tool_dataprivacy\page_helper::setup($url, $title);
+\tool_dataprivacy\page_helper::setup($url, $title, 'dataregistry');
 
 $purpose = new \tool_dataprivacy\purpose($id);
 $form = new \tool_dataprivacy\form\purpose($PAGE->url->out(false),

--- a/purposes.php
+++ b/purposes.php
@@ -27,7 +27,7 @@ require_once(__DIR__ . '/../../../config.php');
 $url = new moodle_url("/admin/tool/dataprivacy/purposes.php");
 $title = get_string('editpurposes', 'tool_dataprivacy');
 
-\tool_dataprivacy\page_helper::setup($url, $title);
+\tool_dataprivacy\page_helper::setup($url, $title, 'dataregistry');
 
 $output = $PAGE->get_renderer('tool_dataprivacy');
 echo $output->header();


### PR DESCRIPTION
The current page_helper class is very specific to the data registry administration.
So I modified it so it can be reused by others (e.g. data deletion, data requests, etc).